### PR TITLE
Make zip-iterator c++20 compliant

### DIFF
--- a/zip_tuple.hpp
+++ b/zip_tuple.hpp
@@ -68,12 +68,12 @@ public:
         return tmp;
     }
 
-    auto operator!=(zip_iterator const & other)
+    auto operator!=(zip_iterator const & other) const
     {
         return !(*this == other);
     }
 
-    auto operator==(zip_iterator const & other)
+    auto operator==(zip_iterator const & other) const
     {
         auto result = false;
         return any_match(m_iters, other.m_iters);

--- a/zip_two.hpp
+++ b/zip_two.hpp
@@ -56,7 +56,7 @@ public:
         return tmp;
     }
 
-    auto operator!=(zip_iterator const & other)
+    auto operator!=(zip_iterator const & other) const
     {
         return !(*this == other);
     }
@@ -71,7 +71,7 @@ public:
         same time. Therefore we need to return true as soon as any of the 
         iterators are at their end position, terminating the iteration loop.
     */
-    auto operator==(zip_iterator const & other)
+    auto operator==(zip_iterator const & other) const
     {
         return 
             m_iter_1_begin == other.m_iter_1_begin ||


### PR DESCRIPTION
When building with c++20 flag, Apple Clang complains on '!=' and '==' operators:

```
ISO C++20 considers use of overloaded operator '!=' to be ambiguous despite there being a unique best viable function with non-reversed arguments [-Werror,-Wambiguous-reversed-operator]
```

Just adding a `const` on both  the operators (as stated [here](https://stackoverflow.com/questions/60386792/)) solves the problem and the code builds also with c++20.