### PR TITLE
Bitwise to logical or change

### DIFF
--- a/zip_tuple.hpp
+++ b/zip_tuple.hpp
@@ -25,7 +25,7 @@ auto any_match_impl(std::tuple<Args...> const & lhs,
     std::index_sequence<Index...>) -> bool
 {
     auto result = false;
-    result = (... | (std::get<Index>(lhs) == std::get<Index>(rhs)));
+    result = (... || (std::get<Index>(lhs) == std::get<Index>(rhs)));
     return result;
 }
 


### PR DESCRIPTION
Fixes #2, as brought forward by clangs warning messages of using bitwise or instead of logical or.