### PR TITLE
Accepting Built-In Arrays

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,15 @@
+set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 cmake_minimum_required(VERSION 3.12)
 project(ZipIterator)
+
+set(FETCHCONTENT_QUIET OFF)
+include(FetchContent)
+FetchContent_Declare(googletest SYSTEM
+  GIT_REPOSITORY https://github.com/google/googletest
+  GIT_TAG v1.13.x
+  GIT_PROGRESS TRUE
+)
+FetchContent_MakeAvailable(googletest)
 
 add_executable(test_zip_two test_zip_two.cpp)
 target_compile_features(test_zip_two PRIVATE cxx_std_17)

--- a/test_zip_tuple.cpp
+++ b/test_zip_tuple.cpp
@@ -1,26 +1,167 @@
 #include "zip_tuple.hpp"
 
-#include <cassert>
 #include <iostream>
-
 #include <iostream>
 #include <memory>
 #include <type_traits>
 
-#include <cxxabi.h>
+
+#include <gtest/gtest.h>
 
 
-auto main() -> int 
+
+
+TEST(ZipTuple, CanIterateVector)
+{
+    auto a = std::vector<int>{1, 2, 3, 4, 5, 6};
+    auto b = std::vector<int>{1, 2, 3, 4, 5, 6};
+    
+    auto expected = std::vector<int>{2, 4, 6, 8, 10, 12};
+    auto result = std::vector<int>{};
+
+    for (auto && [i, j] : c9::zip(a, b)) {
+        result.push_back(i + j);
+    }
+    EXPECT_EQ(result, expected);
+}
+
+
+TEST(ZipTuple, CanAssignZippedByReference)
+{
+    auto a = std::vector<int>{1, 2, 3, 4, 5, 6};
+    auto b = std::vector<int>{1, 2, 3, 4, 5, 6};
+    auto c = std::vector<int>{0, 0, 0, 0, 0, 0};
+
+    for (auto && [i, j, k] : c9::zip(a, b, c)) {
+        k = i + j;
+    }
+    
+    auto expected = std::vector<int>{2, 4, 6, 8, 10, 12};
+    EXPECT_EQ(c, expected);
+}
+
+
+TEST(ZipTuple, WillIterateOverShortestSize)
 {
     auto a = std::vector<int>{1, 2, 3, 4, 5, 6};
     auto b = std::vector<int>{1, 2, 3, 4, 5, 6, 7};
     auto c = std::vector<int>{0, 0, 0, 0, 0};
-    auto const & d = b;
 
-    for (auto && [x, y, z] : c9::zip(a, d, c)) {
-        z = x + y;
+    for (auto && [i, j, k] : c9::zip(a, b, c)) {
+        k = i + j;
     }
     
     auto expected = std::vector<int>{2, 4, 6, 8, 10};
-    assert(c == expected);
+    EXPECT_EQ(c, expected);
+}
+
+
+TEST(ZipTuple, ZippedProvidesReference)
+{
+    auto a = std::vector<int>{1, 2, 3, 4, 5, 6};
+    auto zipper = c9::zip(a);
+    
+    using iter_type = decltype(zipper.begin()); /* zip_iterator<...> */
+    using iter_value_type = iter_type::value_type;
+    using expected_value_type = std::tuple<int&>;
+
+    constexpr static auto is_same = std::is_same_v<
+            iter_value_type,
+            expected_value_type>;
+    EXPECT_TRUE(is_same);
+}
+
+
+TEST(ZipTuple, ConstZippedProvidesConstReference)
+{
+    const auto a = std::vector<int>{1, 2, 3, 4, 5, 6};
+    auto zipper = c9::zip(a);
+    
+    using iter_type = decltype(zipper.begin()); /* zip_iterator<...> */
+    using iter_value_type = iter_type::value_type;
+    using expected_value_type = std::tuple<const int&>;
+
+    constexpr static auto is_same = std::is_same_v<
+            iter_type::value_type, 
+            expected_value_type>;
+    EXPECT_TRUE(is_same);
+}
+
+
+TEST(ZipTuple, MixedZippedProvidesMixedReference)
+{
+    const auto a = std::vector<int>{1, 2, 3, 4, 5, 6};
+    auto b = std::vector<int>{1, 2, 3, 4, 5, 6};
+    auto zipper = c9::zip(a, b);
+    
+    using iter_type = decltype(zipper.begin()); /* zip_iterator<...> */
+    using iter_value_type = iter_type::value_type;
+    using expected_value_type = std::tuple<const int&, int&>;
+
+    constexpr static auto is_same = std::is_same_v<
+            iter_type::value_type, 
+            expected_value_type>;
+    EXPECT_TRUE(is_same);
+}
+
+
+TEST(ZipTuple, CanIterateArray)
+{
+    auto a = std::array<int, 6>{1, 2, 3, 4, 5, 6};
+    auto b = std::array<int, 6>{1, 2, 3, 4, 5, 6};
+    
+    auto expected = std::vector<int>{2, 4, 6, 8, 10, 12};
+    auto result = std::vector<int>{};
+
+    for (auto && [i, j] : c9::zip(a, b)) {
+        result.push_back(i + j);
+    }
+    EXPECT_EQ(result, expected);
+}
+
+
+TEST(ZipTuple, CanIterateRawArray)
+{
+    int a[] = {1, 2, 3, 4, 5, 6};
+    int b[] = {1, 2, 3, 4, 5, 6};
+    
+    auto expected = std::vector<int>{2, 4, 6, 8, 10, 12};
+    auto result = std::vector<int>{};
+
+    for (auto && [i, j] : c9::zip(a, b)) {
+        result.push_back(i + j);
+    }
+    EXPECT_EQ(result, expected);
+}
+
+
+TEST(ZipTuple, CanIterateConstRawArray)
+{
+    const int a[] = {1, 2, 3, 4, 5, 6};
+    const int b[] = {1, 2, 3, 4, 5, 6};
+    
+    auto expected = std::vector<int>{2, 4, 6, 8, 10, 12};
+    auto result = std::vector<int>{};
+
+    for (auto && [i, j] : c9::zip(a, b)) {
+        result.push_back(i + j);
+    }
+    EXPECT_EQ(result, expected);
+}
+
+
+TEST(ZipTuple, CanAssignToVectorOfBool)
+{
+    const auto a = std::vector<bool>{1, 0, 1, 0, 1, 0};
+    const auto b = std::vector<bool>{0, 1, 0, 1, 0, 1};
+
+    
+    auto expected = std::vector<bool>{1, 1, 1, 1, 1, 1};
+    auto result = std::vector<bool>{};
+    result.resize(a.size());
+
+    for (auto && [i, j, k] : c9::zip(a, b, result)) {
+        k = i | j;
+    }
+    EXPECT_EQ(result, expected);
 }

--- a/test_zip_tuple.cpp
+++ b/test_zip_tuple.cpp
@@ -165,3 +165,28 @@ TEST(ZipTuple, CanAssignToVectorOfBool)
     }
     EXPECT_EQ(result, expected);
 }
+
+
+
+
+template <typename T, std::size_t N>
+auto iter_ref(T (&arr)[N])
+{
+    for (auto && [i] : c9::zip(arr)) {
+        i = 0;
+    }
+}
+
+
+TEST(ZipTuple, CanIterateRawArrayReference)
+{
+    int raw[6] = {1, 2, 3, 4, 5, 6};
+    int expected[6] = {0, 0, 0, 0, 0, 0};
+    iter_ref(raw);
+    EXPECT_EQ(raw[0], 0);
+    EXPECT_EQ(raw[1], 0);
+    EXPECT_EQ(raw[2], 0);
+    EXPECT_EQ(raw[3], 0);
+    EXPECT_EQ(raw[4], 0);
+    EXPECT_EQ(raw[5], 0);
+}

--- a/test_zip_two.cpp
+++ b/test_zip_two.cpp
@@ -1,25 +1,159 @@
 #include "zip_two.hpp"
 
-#include <cassert>
 #include <iostream>
-
 #include <iostream>
 #include <memory>
 #include <type_traits>
 
 
+#include <gtest/gtest.h>
 
-auto main() -> int 
+
+
+TEST(ZipTuple, CanIterateVector)
 {
     auto a = std::vector<int>{1, 2, 3, 4, 5, 6};
-    auto const & b = a;
-    auto c = std::vector<int>{};
-
-    for (auto && [x, y] : c9::zip(a, b)) {
-        c.push_back(x + y);
-    }
-
+    auto b = std::vector<int>{1, 2, 3, 4, 5, 6};
+    
     auto expected = std::vector<int>{2, 4, 6, 8, 10, 12};
-    assert(c == expected);
+    auto result = std::vector<int>{};
 
+    for (auto && [i, j] : c9::zip(a, b)) {
+        result.push_back(i + j);
+    }
+    EXPECT_EQ(result, expected);
+}
+
+
+TEST(ZipTuple, CanAssignZippedByReference)
+{
+    auto a = std::vector<int>{1, 2, 3, 4, 5, 6};
+    auto b = std::vector<int>{};
+    b.resize(a.size());
+
+    for (auto && [i, j] : c9::zip(a, b)) {
+        j = i;
+    }
+    
+    EXPECT_EQ(a, b);
+}
+
+
+TEST(ZipTuple, WillIterateOverShortestSize)
+{
+    auto a = std::vector<int>{1, 2, 3};
+    auto b = std::vector<int>{1, 2, 3, 4, 5, 6, 7};
+
+    auto count = 0ull;
+    for (auto && [i, j] : c9::zip(a, b)) {
+        ++count;
+    }
+    
+    EXPECT_EQ(a.size(), count);
+}
+
+
+TEST(ZipTuple, ZippedProvidesReference)
+{
+    auto a = std::vector<int>{1, 2, 3, 4, 5, 6};
+    auto zipper = c9::zip(a, a);
+    
+    using iter_type = decltype(zipper.begin()); /* zip_iterator<...> */
+    using iter_value_type = iter_type::value_type;
+    using expected_value_type = std::pair<int&, int&>;
+
+    constexpr static auto is_same = std::is_same_v<
+            iter_value_type,
+            expected_value_type>;
+    EXPECT_TRUE(is_same);
+}
+
+
+TEST(ZipTuple, ConstZippedProvidesConstReference)
+{
+    const auto a = std::vector<int>{1, 2, 3, 4, 5, 6};
+    auto zipper = c9::zip(a, a);
+    
+    using iter_type = decltype(zipper.begin()); /* zip_iterator<...> */
+    using iter_value_type = iter_type::value_type;
+    using expected_value_type = std::pair<int const &, int const &>;
+
+    constexpr static auto is_same = std::is_same_v<
+            iter_value_type,
+            expected_value_type>;
+    EXPECT_TRUE(is_same);
+}
+
+
+TEST(ZipTuple, MixedZippedProvidesMixedReference)
+{
+    const auto a = std::vector<int>{1, 2, 3, 4, 5, 6};
+    auto b = std::vector<int>{1, 2, 3, 4, 5, 6};
+    auto zipper = c9::zip(a, b);
+    
+    using iter_type = decltype(zipper.begin()); /* zip_iterator<...> */
+    using iter_value_type = iter_type::value_type;
+    using expected_value_type = std::pair<const int&, int&>;
+
+    constexpr static auto is_same = std::is_same_v<
+            iter_type::value_type, 
+            expected_value_type>;
+    EXPECT_TRUE(is_same);
+}
+
+
+TEST(ZipTuple, CanIterateArray)
+{
+    auto a = std::array<int, 6>{1, 2, 3, 4, 5, 6};
+    auto b = std::array<int, 6>{1, 2, 3, 4, 5, 6};
+    
+    auto expected = std::vector<int>{2, 4, 6, 8, 10, 12};
+    auto result = std::vector<int>{};
+
+    for (auto && [i, j] : c9::zip(a, b)) {
+        result.push_back(i + j);
+    }
+    EXPECT_EQ(result, expected);
+}
+
+
+TEST(ZipTuple, CanIterateRawArray)
+{
+    int a[] = {1, 2, 3, 4, 5, 6};
+    int b[] = {1, 2, 3, 4, 5, 6};
+    
+    auto expected = std::vector<int>{2, 4, 6, 8, 10, 12};
+    auto result = std::vector<int>{};
+
+    for (auto && [i, j] : c9::zip(a, b)) {
+        result.push_back(i + j);
+    }
+    EXPECT_EQ(result, expected);
+}
+
+
+TEST(ZipTuple, CanIterateConstRawArray)
+{
+    const int a[] = {1, 2, 3, 4, 5, 6};
+    const int b[] = {1, 2, 3, 4, 5, 6};
+    
+    auto expected = std::vector<int>{2, 4, 6, 8, 10, 12};
+    auto result = std::vector<int>{};
+
+    for (auto && [i, j] : c9::zip(a, b)) {
+        result.push_back(i + j);
+    }
+    EXPECT_EQ(result, expected);
+}
+
+
+TEST(ZipTuple, CanAssignToVectorOfBool)
+{
+    const auto a = std::vector<bool>{1, 0, 1, 0, 1, 0};
+    auto b = std::vector<bool>{0, 0, 0, 0, 0, 0};
+
+    for (auto && [i, j] : c9::zip(a, b)) {
+        j = i;
+    }
+    EXPECT_EQ(a, b);
 }

--- a/zip_tuple.hpp
+++ b/zip_tuple.hpp
@@ -11,13 +11,7 @@
 namespace c9 {
 
 template <typename Iter>
-using select_access_type_for = std::conditional_t<
-    std::is_same_v<Iter, std::vector<bool>::iterator> ||
-    std::is_same_v<Iter, std::vector<bool>::const_iterator>,
-    typename Iter::value_type,
-    typename Iter::reference
->;
-
+using select_access_type_for = std::remove_reference_t<decltype(*std::declval<Iter&>())>;
 
 template <typename ... Args, std::size_t ... Index>
 auto any_match_impl(std::tuple<Args...> const & lhs,
@@ -90,13 +84,8 @@ private:
     std::tuple<Iters...> m_iters;
 };
 
-
-/* std::decay needed because T is a reference, and is not a complete type */
 template <typename T>
-using select_iterator_for = std::conditional_t<
-    std::is_const_v<std::remove_reference_t<T>>, 
-    typename std::decay_t<T>::const_iterator,
-    typename std::decay_t<T>::iterator>;
+using select_iterator_for = decltype(std::begin(std::declval<T&>()));
 
 
 

--- a/zip_tuple.hpp
+++ b/zip_tuple.hpp
@@ -13,7 +13,7 @@
 namespace c9 {
 
 template <typename Iter>
-using select_access_type_for = decltype(*std::declval<Iter&>());
+using select_access_type_for = typename std::iterator_traits<Iter>::reference;
 
 template <typename ... Args, std::size_t ... Index>
 auto any_match_impl(std::tuple<Args...> const & lhs,
@@ -88,7 +88,6 @@ private:
 
 template <typename T>
 using select_iterator_for = decltype(std::begin(std::declval<T&>()));
-
 
 
 template <typename ... T>

--- a/zip_tuple.hpp
+++ b/zip_tuple.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <cassert>
 #include <functional>
 #include <iomanip>

--- a/zip_tuple.hpp
+++ b/zip_tuple.hpp
@@ -13,7 +13,7 @@
 namespace c9 {
 
 template <typename Iter>
-using select_access_type_for = std::remove_reference_t<decltype(*std::declval<Iter&>())>;
+using select_access_type_for = decltype(*std::declval<Iter&>());
 
 template <typename ... Args, std::size_t ... Index>
 auto any_match_impl(std::tuple<Args...> const & lhs,

--- a/zip_two.hpp
+++ b/zip_two.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <type_traits>
 #include <vector>
 


### PR DESCRIPTION
zip_tuple can now iterate over built in arrays too and does not need containers like `std::vector<int>`